### PR TITLE
Windows support: normalize line endings and path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+### 0.3.1
+
+- Add `intendation` option. Defaults to `"  "` (two spaces)
+- Remove generated fixtures via `npm run clean`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-### 0.3.1
+### 0.3.2
 
-- Add `intendation` option. Defaults to `"  "` (two spaces)
-- Remove generated fixtures via `npm run clean`
+- Switch to 4 spaces intendation
+- Add `intendation` option. Defaults to `"    "` (four spaces)
+- Delete generated fixtures via `npm run clean`
+

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Only new unique `defaultMessage` appended as `descriptor` at the end of previous
 
 - **`messagesDir`**: The target location where the plugin will output a `.js` file corresponding to each component from which messages were extracted. If not provided, the extracted message descriptors will only be accessible via Babel's API.
 
-- **`intendation`**: A string that will be used to intend the generated messages. Defaults to `"  "` (two spaces ).
+- **`intendation`**: A string that will be used to intend the generated messages. Defaults to `"    "` (four spaces ).
 
 ### Via CLI
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # babel-plugin-react-intl-messages-generator
 Build skeleton `messages` files with `defineMessage` format for each component that contains explicit texts
 
+___This is a fork of that fixes some issues on Windows systems.___
+Hopefully the fork will become obsolete after the issues have been fixed or the solutions merged.
+The original project is located at https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator and https://www.npmjs.com/package/babel-plugin-react-intl-messages-generator.
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Only new unique `defaultMessage` appended as `descriptor` at the end of previous
 
 - **`messagesDir`**: The target location where the plugin will output a `.js` file corresponding to each component from which messages were extracted. If not provided, the extracted message descriptors will only be accessible via Babel's API.
 
+- **`intendation`**: A string that will be used to intend the generated messages. Defaults to `"  "` (two spaces ).
 
 ### Via CLI
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopmode/babel-plugin-react-intl-messages-generator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Extracts explicit texts from react components and generate a componentNameMessages.js files. Forked from https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator, added Windows compatibility",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "lint": "eslint src/",
-    "clean": "rimraf lib/",
+    "clean": "rimraf lib/ && rimraf test/fixtures/*/actualMessages.js",
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register",
     "build": "babel src/ --out-dir lib/",
     "build:fixtures": "babel-node ./scripts/build-fixtures.js",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
-  "name": "babel-plugin-react-intl-messages-generator",
+  "name": "babel-plugin-react-intl-messages-generator-compat",
   "version": "0.3.0",
-  "description": "Extracts explicit texts from react components and generate a componentNameMessages.js files",
+  "description": "Extracts explicit texts from react components and generate a componentNameMessages.js files. Forked from https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator, added Windows compatibility",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator.git"
+    "url": "git+https://github.com/loopmode/babel-plugin-react-intl-messages-generator.git"
   },
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
   "author": "Peramanathan Sathyamoorthy <sathyam.peram@gmail.com>",
+  "contributors": [
+    "Jovica Aleksic <jovica.aleksic@loopmode.de> (https://github.com/loopmode)"
+  ],
   "dependencies": {
     "babel-runtime": "^6.2.0",
     "mkdirp": "^0.5.1"
@@ -44,7 +47,7 @@
     "defineMessages"
   ],
   "bugs": {
-    "url": "https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator/issues"
+    "url": "https://github.com/loopmode/babel-plugin-react-intl-messages-generator/issues"
   },
-  "homepage": "https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator#readme"
+  "homepage": "https://github.com/loopmode/babel-plugin-react-intl-messages-generator#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopmode/babel-plugin-react-intl-messages-generator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Extracts explicit texts from react components and generate a componentNameMessages.js files. Forked from https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator, added Windows compatibility",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-plugin-react-intl-messages-generator-compat",
+  "name": "@loopmode/babel-plugin-react-intl-messages-generator",
   "version": "0.3.0",
   "description": "Extracts explicit texts from react components and generate a componentNameMessages.js files. Forked from https://github.com/p10ns11y/babel-plugin-react-intl-messages-generator, added Windows compatibility",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "dependencies": {
     "babel-runtime": "^6.2.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "eol": "^0.9.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",
@@ -25,7 +26,6 @@
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.11.6",
     "cross-env": "^2.0.0",
-    "eol": "^0.9.0",
     "eslint": "^2.9.0",
     "eslint-plugin-react": "^6.1.2",
     "mocha": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-register": "^6.11.6",
     "cross-env": "^2.0.0",
+    "eol": "^0.9.0",
     "eslint": "^2.9.0",
     "eslint-plugin-react": "^6.1.2",
     "mocha": "^3.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@
 import * as p from 'path';
 import { writeFileSync, existsSync, readFileSync } from 'fs';
 import { sync as mkdirpSync } from 'mkdirp';
+import eol from 'eol';
 
 import {
   createDescriptorsWithKey,
@@ -39,7 +40,7 @@ export default function({ types: t }) { // eslint-disable-line no-unused-vars
 
     const prefixId = p
       .relative(process.cwd(), file.opts.filename)
-      .split('/')
+      .split(p.sep)
       .join('.')
       .replace(/jsx?/, '..');
 
@@ -75,7 +76,7 @@ export default function({ types: t }) { // eslint-disable-line no-unused-vars
             let relativePath = p.join(
               p.sep,
               p.relative(process.cwd(), filename)
-            );
+            ).replace(/\\/g, '/');
 
             let generatedMessagesFilename = p.join(
               opts.messagesDir,
@@ -122,13 +123,13 @@ export default function({ types: t }) { // eslint-disable-line no-unused-vars
                 updatedNamedDescriptors
               );
 
-              writeFileSync(generatedMessagesFilename, updatedDescriptorFile);
+              writeFileSync(generatedMessagesFilename, eol.lf(updatedDescriptorFile));
             }
 
             // new file
             if (!existingContent && namedDesriptors) {
               let generatedDescriptorFile = defineMessageFormat(namedDesriptors);
-              writeFileSync(generatedMessagesFilename, generatedDescriptorFile);
+              writeFileSync(generatedMessagesFilename, eol.lf(generatedDescriptorFile));
             }
             // else keep the file untouched
           }

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export default function({ types: t }) { // eslint-disable-line no-unused-vars
                   }
                 }
 
-                descriptorsWithKey += createDescriptorsWithKey(descriptor);
+                descriptorsWithKey += createDescriptorsWithKey(descriptor, opts);
                 return descriptorsWithKey;
               },
               ''

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,11 +13,11 @@ export const removeDefindeMessageFormat = (fileContent) =>
   .replace(`export default defineMessages({\n`, '')
   .replace('\n});', '');
 
-export const createDescriptorsWithKey = (descriptor, {intendation = '  '}) => {
+export const createDescriptorsWithKey = (descriptor, {intendation = '    '}) => {
   const lintFixedDescriptor = JSON.stringify(descriptor, null, 4)
     .replace('}', `${intendation}}`)
-    .replace('"id"', 'id')
-    .replace('"defaultMessage"', 'defaultMessage')
+    .replace('"id"', `${intendation}id`)
+    .replace('"defaultMessage"', `${intendation}defaultMessage`)
     .replace(/\"/g, "'");
 
   const descriptorsWithKey = `${intendation}NameTheKey: ${lintFixedDescriptor},\n`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,13 +13,13 @@ export const removeDefindeMessageFormat = (fileContent) =>
   .replace(`export default defineMessages({\n`, '')
   .replace('\n});', '');
 
-export const createDescriptorsWithKey = (descriptor) => {
+export const createDescriptorsWithKey = (descriptor, {intendation = '  '}) => {
   const lintFixedDescriptor = JSON.stringify(descriptor, null, 4)
-    .replace('}', '  }')
+    .replace('}', `${intendation}}`)
     .replace('"id"', 'id')
     .replace('"defaultMessage"', 'defaultMessage')
     .replace(/\"/g, "'");
 
-  const descriptorsWithKey = `  NameTheKey: ${lintFixedDescriptor},\n`;
+  const descriptorsWithKey = `${intendation}NameTheKey: ${lintFixedDescriptor},\n`;
   return descriptorsWithKey;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import eol from 'eol';
+
 export const defineMessageFormat = (descriptors) =>
 `import { defineMessages } from 'react-intl';
 
@@ -6,7 +8,7 @@ export default defineMessages({\n${descriptors}});
 `;
 
 export const removeDefindeMessageFormat = (fileContent) =>
-  fileContent
+  eol.lf(fileContent)
   .replace(`import { defineMessages } from 'react-intl';\n\n`, '')
   .replace(`export default defineMessages({\n`, '')
   .replace('\n});', '');

--- a/test/fixtures/componentMessages/expectedMessages.js
+++ b/test/fixtures/componentMessages/expectedMessages.js
@@ -1,12 +1,12 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  NameTheKey: {
-    id: 'test.fixtures.componentMessages.actual...',
-    defaultMessage: 'Hello'
-  },
-  NameTheKey: {
-    id: 'test.fixtures.componentMessages.actual...',
-    defaultMessage: 'world'
-  },
+    NameTheKey: {
+        id: 'test.fixtures.componentMessages.actual...',
+        defaultMessage: 'Hello'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.componentMessages.actual...',
+        defaultMessage: 'world'
+    },
 });

--- a/test/fixtures/componentWithNewMessages/actualWithNewMessages.js
+++ b/test/fixtures/componentWithNewMessages/actualWithNewMessages.js
@@ -1,12 +1,16 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  helloTxt: {
-    id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.hello',
-    defaultMessage: 'Hello'
-  },
-  worldTxt: {
-    id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.world',
-    defaultMessage: 'world'
-  },
+    helloTxt: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.hello',
+        defaultMessage: 'Hello'
+    },
+    worldTxt: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.world',
+        defaultMessage: 'world'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew...',
+        defaultMessage: 'New message'
+    },
 });

--- a/test/fixtures/componentWithNewMessages/expectedMessages.js
+++ b/test/fixtures/componentWithNewMessages/expectedMessages.js
@@ -1,16 +1,16 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  helloTxt: {
-    id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.hello',
-    defaultMessage: 'Hello'
-  },
-  worldTxt: {
-    id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.world',
-    defaultMessage: 'world'
-  },
-  NameTheKey: {
-    id: 'test.fixtures.componentWithNewMessages.actualWithNew...',
-    defaultMessage: 'New message'
-  },
+    helloTxt: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.hello',
+        defaultMessage: 'Hello'
+    },
+    worldTxt: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew.text.world',
+        defaultMessage: 'world'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.componentWithNewMessages.actualWithNew...',
+        defaultMessage: 'New message'
+    },
 });

--- a/test/fixtures/duplicateMessages/expectedMessages.js
+++ b/test/fixtures/duplicateMessages/expectedMessages.js
@@ -1,16 +1,16 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  NameTheKey: {
-    id: 'test.fixtures.duplicateMessages.actual...',
-    defaultMessage: 'Hello'
-  },
-  NameTheKey: {
-    id: 'test.fixtures.duplicateMessages.actual...',
-    defaultMessage: 'world'
-  },
-  NameTheKey: {
-    id: 'test.fixtures.duplicateMessages.actual...',
-    defaultMessage: 'Hello world'
-  },
+    NameTheKey: {
+        id: 'test.fixtures.duplicateMessages.actual...',
+        defaultMessage: 'Hello'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.duplicateMessages.actual...',
+        defaultMessage: 'world'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.duplicateMessages.actual...',
+        defaultMessage: 'Hello world'
+    },
 });

--- a/test/fixtures/skipNumberMessages/expectedMessages.js
+++ b/test/fixtures/skipNumberMessages/expectedMessages.js
@@ -1,8 +1,8 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  NameTheKey: {
-    id: 'test.fixtures.skipNumberMessages.actual...',
-    defaultMessage: '1 it is ok to have numbers with text'
-  },
+    NameTheKey: {
+        id: 'test.fixtures.skipNumberMessages.actual...',
+        defaultMessage: '1 it is ok to have numbers with text'
+    },
 });

--- a/test/fixtures/statelessComponentMessages/expectedMessages.js
+++ b/test/fixtures/statelessComponentMessages/expectedMessages.js
@@ -1,12 +1,12 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  NameTheKey: {
-    id: 'test.fixtures.statelessComponentMessages.actual...',
-    defaultMessage: 'I am stateless Component'
-  },
-  NameTheKey: {
-    id: 'test.fixtures.statelessComponentMessages.actual...',
-    defaultMessage: 'I love props a lot!'
-  },
+    NameTheKey: {
+        id: 'test.fixtures.statelessComponentMessages.actual...',
+        defaultMessage: 'I am stateless Component'
+    },
+    NameTheKey: {
+        id: 'test.fixtures.statelessComponentMessages.actual...',
+        defaultMessage: 'I love props a lot!'
+    },
 });

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,15 @@ import * as path from 'path';
 import * as fs from 'fs';
 import assert from 'power-assert';
 import * as babel from 'babel-core';
+import eol from 'eol';
 import plugin from '../src/index';
 
 function trim(str) {
   return str.toString().replace(/^\s+|\s+$/, '');
 }
-
+function normalize(str) {
+  return eol.lf(trim(str));
+}
 const skipTests = [
   '.babelrc',
   '.DS_Store',
@@ -37,12 +40,12 @@ describe('emit asserts for: ', () => {
 
       // Check code output
       const expected = fs.readFileSync(path.join(fixtureDir, 'expected.js'));
-      assert.equal(trim(actual), trim(expected));
+      assert.equal(normalize(actual), normalize(expected));
 
       // Check generated message output
       const expectedGenMessages = fs.readFileSync(path.join(fixtureDir, 'expectedMessages.js'));
       const actualGenMessages = fs.readFileSync(path.join(fixtureDir, actualFileName + 'Messages.js'));
-      assert.equal(trim(actualGenMessages), trim(expectedGenMessages));
+      assert.equal(normalize(actualGenMessages), normalize(expectedGenMessages));
     });
   });
 });


### PR DESCRIPTION
The issue at hand is that when used on a windows system, you end up with ugly message IDs, e.g. `app\\components\\Foo` instead of `app.components.Foo`.
This pull requests fixes that. Tests are adjusted and succeed.

Changes:
- Normalizing line endings a couple of times using [eol.lf](https://www.npmjs.com/package/eol#eollftext)
- Replacing backslashes by forward slashes in one place - shouldn't do any harm on non-win systems.

Very strange. The [travis build failed](https://travis-ci.org/p10ns11y/babel-plugin-react-intl-messages-generator/builds/257623907) on node 0.12 with `ESLint couldn't find the plugin "eslint-plugin-react".` - which is pretty weird as that's just a dependency in package.json - `npm install` log shows it was installed.